### PR TITLE
Remove "bug" label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,6 @@
 name: Bug report
 about: Report something that isn't working.
 title: ''
-labels: bug
 assignees: ''
 
 ---


### PR DESCRIPTION
Labels created with issue template are not searchable and repositories already have "bug" label.

Here is an example from [deltachat-desktop](https://github.com/deltachat/deltachat-desktop/issues). Green "bug" label is searchable, red is created with template and is not searchable:
![1](https://user-images.githubusercontent.com/18373967/89694081-33853880-d919-11ea-9bd5-993fa2011f09.png)

Searching for `label:bug` returns only issues labeled with green per-project label.
