### PR TITLE
remove IRC from fontpage

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -17,7 +17,6 @@
 - Read our [Frequently Asked Questions](https://delta.chat/en/help)
 - Ask a question or suggest a feature in our [Forum](https://support.delta.chat/)
 - Follow us on [Fediverse](https://chaos.social/web/@delta) for announcements.
-- Talk with us over IRC #deltachat on Libera.Chat ([webclient](https://web.libera.chat/#deltachat))
 - Translate Delta Chat into your language on [Transifex](https://www.transifex.com/delta-chat/public/)
 
 <!--

--- a/profile/README.md
+++ b/profile/README.md
@@ -15,7 +15,7 @@
 
 - Visit our website: https://delta.chat
 - Read our [Frequently Asked Questions](https://delta.chat/en/help)
-- Ask a question or suggest a feature in our [Forum](https://support.delta.chat/)
+- Ask a question or suggest a feature in our [Forum](https://support.delta.chat/) or on [other channels](https://delta.chat/en/contribute)
 - Follow us on [Fediverse](https://chaos.social/web/@delta) for announcements.
 - Translate Delta Chat into your language on [Transifex](https://www.transifex.com/delta-chat/public/)
 


### PR DESCRIPTION
i think, there are too few ppl hanging out to justify a direct link, it is also removed from https://delta.chat/en/contribute